### PR TITLE
Update build.gradle

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -33,6 +33,10 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     compileSdkVersion flutter.compileSdkVersion
     ndkVersion flutter.ndkVersion
+    
+    defaultConfig {
+        compileSdk 34
+    }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -35,7 +35,7 @@ android {
     ndkVersion flutter.ndkVersion
     
     defaultConfig {
-        compileSdk 34
+        compileSdk 33
     }
 
     compileOptions {


### PR DESCRIPTION
Fixed bug This Android Gradle plugin (7.4.2) was tested up to compileSdk = 33

This warning can be suppressed by adding
    android.suppressUnsupportedCompileSdk=34
to this project's gradle.properties

The build will continue, but you are strongly encouraged to update your project to use a newer Android Gradle Plugin that has been tested with compileSdk = 34