### PR TITLE
fix(ci): linux appimage black screen

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -88,7 +88,10 @@ jobs:
           chmod +x AppDir/maid
           echo '#!/bin/bash
           HERE="$(dirname "$(readlink -f "${0}")")"
-          exec "$HERE/maid" "$@"' > AppDir/AppRun
+          (
+            export LD_LIBRARY_PATH="${HERE}/lib:${LD_LIBRARY_PATH}"
+            exec "${HERE}/maid" "$@"
+          )' > AppDir/AppRun
           chmod +x AppDir/AppRun
 
       - name: Create AppImage


### PR DESCRIPTION
This is probably not the right way to fix this, but it fixes `libbabylon.so` and `libonnxruntime.so.1.18.1` not being found.