### PR TITLE
Add markdown rendering

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -33,6 +33,9 @@ import 'package:ollama_dart/ollama_dart.dart' as ollama;
 import 'package:openai_dart/openai_dart.dart' as open_ai;
 import 'package:mistralai_dart/mistralai_dart.dart' as mistral;
 import 'package:url_launcher/url_launcher.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:flutter/gestures.dart'; // needed for Markdown selectable text
+
 
 part 'controllers/app_settings.dart';
 part 'controllers/artificial_intelligence_controller.dart';

--- a/lib/widgets/message/message.dart
+++ b/lib/widgets/message/message.dart
@@ -144,10 +144,26 @@ class MessageWidgetState extends State<MessageWidget> {
       if (part.isEmpty) continue;
 
       if (i % 2 == 0) {
-        children.add(SelectableText(part));
+        children.add(
+          MarkdownBody(
+            data: part,
+            selectable: true,
+            onTapLink: (text, href, title) {
+              if (href != null) launchUrl(Uri.parse(href));
+            },
+            styleSheet: MarkdownStyleSheet.fromTheme(Theme.of(context)).copyWith(
+              p: Theme.of(context).textTheme.bodyMedium,
+              code: Theme.of(context).textTheme.bodySmall?.copyWith(
+                backgroundColor: Theme.of(context).colorScheme.surfaceVariant,
+                fontFamily: 'monospace',
+              ),
+            ),
+          ),
+        );
       } else {
         children.add(CodeBox(code: part, label: AppLocalizations.of(context)!.code));
       }
+
     }
 
     children.add(buildTime());

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,9 @@ dependencies:
   network_info_plus: ^6.1.3
   lan_scanner: ^4.0.0+1
 
+  # For markdown
+  flutter_markdown: ^0.7.2
+
   # The maintainer of this package has not updated the package on pub.dev
   # https://github.com/KasemJaffer/receive_sharing_intent/issues/354
   receive_sharing_intent:


### PR DESCRIPTION
- Render plain-text message parts as Markdown using flutter_markdown, enabling selectable formatted text and clickable links.
- Add flutter_markdown dependency in pubspec.yaml.
- Use MarkdownBody with selectable: true and onTapLink to open links.
- Apply basic styling for paragraphs and inline code to match app theme.

Files changed:
- lib/main.dart — import flutter_markdown and gestures for selectable text.
- lib/widgets/message/message.dart — replace SelectableText with MarkdownBody for message parts; preserve code blocks with CodeBox.
- pubspec.yaml — add flutter_markdown: ^0.7.2 dependency.

Why:
- Improves message rendering (links, formatting, inline code) and allows users to select/copy formatted text.
- Minimal, focused change that preserves existing code-block handling.

Testing notes:
- [x]  Test on Linux 
<details> <summary> Results  </summary>

<img width="1913" height="706" alt="Bildschirmfoto_20251024_203156" src="https://github.com/user-attachments/assets/1ab1e3a9-6da9-444f-8006-fdd0ed42f3ef" />

</details>

 - [x] Test on Android (Android 13)
<details> <summary> Results  </summary>

<img width="1080" height="2174" alt="1000027013-edited" src="https://github.com/user-attachments/assets/eb30440c-6fb5-49d5-96a6-a90ce25bb5c5" />

</details>