### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/context/artificial-intelligence/language-model/anthropic.tsx
+++ b/context/artificial-intelligence/language-model/anthropic.tsx
@@ -226,7 +226,7 @@ export function AnthropicProvider({ children }: { children: React.ReactNode }) {
     setBusy(true);
 
     try {
-      const parts = await anthropic.messages.stream({
+      await anthropic.messages.stream({
         model,
         max_tokens: 1024,
         stream: true,


### PR DESCRIPTION
General fix: remove the unused variable binding while preserving the side effects of the `anthropic.messages.stream(...)` call, or alternatively, use the variable meaningfully (e.g., to manage the stream). Since the current code does not require further interaction with `parts`, the simplest fix is to drop the `const parts =` binding.

Best fix in detail: replace the `const parts = await anthropic.messages.stream(...).on(...)` line with a direct `await anthropic.messages.stream(...).on(...)` expression. This keeps the behavior (starting and awaiting the stream, calling `onUpdate` on each text event) and removes the unused variable, satisfying CodeQL while not altering visible functionality.

Specific change: in `context/artificial-intelligence/language-model/anthropic.tsx`, within the `promptModel` function around lines 228–239, edit the block so that `const parts =` is removed, leaving an `await` call only. No new imports or helper methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._