### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/hooks/use-synced-image.ts
+++ b/hooks/use-synced-image.ts
@@ -117,9 +117,6 @@ function useSyncedImage(
     if (!imageUri || imageUri.startsWith("http")) return;
 
     try {
-      const resp = await fetch(uri);
-      const blob = await resp.blob();
-
       const path = `${user.id}.jpg`;
 
       await uploadImageFromUri({


### PR DESCRIPTION
In general, unused variables should either be removed (along with any unnecessary computation that produced them) or the code should be corrected to actually use them in the intended logic. Here, `resp` and `blob` are computed but never used; the upload function `uploadImageFromUri` already accepts a `uri` and performs the necessary reading itself. The cleanest fix without changing functionality is to remove the redundant `fetch`/`blob` code and the `blob` variable, allowing `saveSupabase` to simply delegate to `uploadImageFromUri` with the existing `uri` argument.

Concretely, in `hooks/use-synced-image.ts`, inside `saveSupabase`, delete the lines that perform `const resp = await fetch(uri);` and `const blob = await resp.blob();`, and keep the rest intact. The call to `uploadImageFromUri` should remain as-is, still using `uri: imageUri!`. No new imports or helpers are needed, and no other logic needs to change. This removes the unused `blob` variable and the unnecessary network/body-read, preserving functional behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._