### PR TITLE
Fix for Semicolon insertion

### DIFF
--- a/components/views/message-content-view.tsx
+++ b/components/views/message-content-view.tsx
@@ -248,7 +248,7 @@ function MessageContentView({ message }: { message: MessageNode }) {
         </View>
       )}
     </View>
-  )
+  );
 };
 
 export default MessageContentView;


### PR DESCRIPTION
To fix the problem, we should terminate the `return` statement explicitly with a semicolon after the JSX block, rather than relying on automatic semicolon insertion. This keeps the style consistent and removes any ambiguity for JavaScript’s parser.

Concretely, in `components/views/message-content-view.tsx`, at the end of the `MessageContentView` function, change the final line of the `return` block from `)` to `);`. This is the only functional edit required. No imports or additional definitions are needed, and existing functionality remains identical because adding a semicolon after a completed `return` expression does not change runtime behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._