### PR TITLE
Fix for Semicolon insertion

### DIFF
--- a/context/artificial-intelligence/language-model/anthropic.tsx
+++ b/context/artificial-intelligence/language-model/anthropic.tsx
@@ -247,7 +247,7 @@ export function AnthropicProvider({ children }: { children: React.ReactNode }) {
 
   const resetBaseURL = () => {
     setBaseURL(DEFAULT_BASE_URL);
-  }
+  };
 
   const value = {
     ready: !!anthropic && !!model,


### PR DESCRIPTION
To fix the problem, ensure that the `const resetBaseURL = () => { ... }` declaration ends with an explicit semicolon, matching the style of other statements in the function and avoiding reliance on automatic semicolon insertion. This maintains current behavior while satisfying the CodeQL rule and improving readability.

Concretely, in `context/artificial-intelligence/language-model/anthropic.tsx`, update the `resetBaseURL` function definition so that the closing brace is followed by a semicolon. No other code changes, imports, or new definitions are necessary, since we are not altering functionality—only making the termination of the statement explicit.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._