### PR TITLE
Fix for Semicolon insertion

### DIFF
--- a/context/artificial-intelligence/language-model/llama.tsx
+++ b/context/artificial-intelligence/language-model/llama.tsx
@@ -209,7 +209,7 @@ export function LlamaProvider({ children }: { children: ReactNode }) {
 
     setModelFiles({ ...updatedModelFiles, [name]: newPath });
     setModelFileKey(name);
-  }
+  };
 
   const promptModel = async (
     messages: Array<MessageNode>, 


### PR DESCRIPTION
To fix the problem, we should terminate the assignment to `pickModelFile` with an explicit semicolon so that it no longer relies on automatic semicolon insertion. This keeps the style consistent with the surrounding code and avoids possible ambiguities if code is later added on the next line that could interact badly with ASI.

Concretely, in `context/artificial-intelligence/language-model/llama.tsx`, locate the end of the `pickModelFile` function definition (currently ending with `}` on line 212) and change it to `};`. No new imports or additional code are required. This preserves existing functionality while making the termination of the statement explicit.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._