### PR TITLE
Fix for Semicolon insertion

### DIFF
--- a/context/artificial-intelligence/language-model/mistral.tsx
+++ b/context/artificial-intelligence/language-model/mistral.tsx
@@ -212,7 +212,7 @@ export function MistralProvider({ children }: { children: React.ReactNode }) {
 
   const resetBaseURL = () => {
     setBaseURL(DEFAULT_BASE_URL);
-  }
+  };
 
   const value = {
     ready: !!mistral && !!model,


### PR DESCRIPTION
To fix the problem, avoid relying on automatic semicolon insertion by explicitly terminating the `resetBaseURL` assignment statement with a semicolon. In general, for function expressions assigned to variables (`const fn = () => { ... }`), you should end the assignment with a semicolon to match other statements and to avoid ASI pitfalls when adding/changing lines later.

Concretely, in `context/artificial-intelligence/language-model/mistral.tsx`, locate the definition:

```ts
  const resetBaseURL = () => {
    setBaseURL(DEFAULT_BASE_URL);
  }
```

and add a semicolon after the closing brace so that it becomes:

```ts
  const resetBaseURL = () => {
    setBaseURL(DEFAULT_BASE_URL);
  };
```

No additional imports, methods, or definitions are needed; this change does not alter functionality and only improves syntactic consistency and safety.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._