### PR TITLE
Fix for Semicolon insertion

### DIFF
--- a/context/artificial-intelligence/language-model/ollama.tsx
+++ b/context/artificial-intelligence/language-model/ollama.tsx
@@ -195,7 +195,7 @@ export function OllamaProvider({ children }: { children: React.ReactNode }) {
       onUpdate(chunk.message.content);
     }
     setBusy(false);
-  }
+  };
 
   const value = { 
     ready: !!ollama && !!model,


### PR DESCRIPTION
To fix the problem, we should explicitly terminate the `promptModel` assignment statement with a semicolon, instead of relying on automatic semicolon insertion. This means adding a semicolon immediately after the closing brace of the arrow function body.

Concretely, in `context/artificial-intelligence/language-model/ollama.tsx`, within the `OllamaProvider` component definition, locate the `const promptModel = async (` declaration. At the end of that arrow function, after the existing `setBusy(false);` line and the closing brace `}`, add a semicolon so it becomes `};`. No additional imports or helper methods are required; this is a simple syntactic/style change that preserves existing functionality while removing dependence on ASI and aligning with the rest of the file's style.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._