### PR TITLE
Fix for Missing await

### DIFF
--- a/context/artificial-intelligence/language-model/llama.tsx
+++ b/context/artificial-intelligence/language-model/llama.tsx
@@ -192,7 +192,7 @@ export function LlamaProvider({ children }: { children: ReactNode }) {
     if (file.assets === null) return;
     const asset = file.assets[0];
 
-    if (!/\.gguf$/i.test(asset.uri) || !isGGUF(asset.uri)) {
+    if (!/\.gguf$/i.test(asset.uri) || !(await isGGUF(asset.uri))) {
       alert("Please select a valid GGUF model file");
       return;
     }


### PR DESCRIPTION
To fix the problem, the promise returned by `isGGUF(asset.uri)` must be awaited so that the `if` condition operates on a `boolean` instead of a `Promise<boolean>`. Since `pickModelFile` is already declared as `async`, we can safely use `await` inside it without changing its external behavior (it already returns a promise). The best fix is to update the condition at line 195 to `if (!/\.gguf$/i.test(asset.uri) || !(await isGGUF(asset.uri))) { ... }`. This preserves the original logic: first check the file extension, then check the content header. No additional imports or helper methods are necessary.

Concretely, in `context/artificial-intelligence/language-model/llama.tsx`, replace the line:

```ts
195:     if (!/\.gguf$/i.test(asset.uri) || !isGGUF(asset.uri)) {
```

with:

```ts
195:     if (!/\.gguf$/i.test(asset.uri) || !(await isGGUF(asset.uri))) {
```

No other changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._