### PR TITLE
Fix for Semicolon insertion

### DIFF
--- a/components/views/parameter-view.tsx
+++ b/components/views/parameter-view.tsx
@@ -167,7 +167,7 @@ function ParameterViewItem(props: ParameterViewItemProps) {
     setParameters((prev: Record<string, string | number | boolean>) => ({ ...prev, [key]: parsedValue }));
 
     setValue(newValue);
-  }
+  };
 
   return (
     <View style={styles.container}>


### PR DESCRIPTION
To fix this, we should explicitly terminate the statement that assigns the arrow function to `updateParameter` with a semicolon. This removes reliance on automatic semicolon insertion and makes the code style consistent with the rest of the file.

Concretely, in `components/views/parameter-view.tsx`, locate the `updateParameter` arrow function inside `ParameterViewItem`. After the closing brace of the function body (currently on line 170), add a semicolon so that `const updateParameter = (...) => { ... }` becomes `const updateParameter = (...) => { ... };`. No additional imports, methods, or other code changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._