### PR TITLE
feat: Add Novita as an optional LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@
 </a>
 </div>
 
-Maid is a free and open source application for interfacing with llama.cpp models locally, and with Anthropic, DeepSeek, Ollama, Mistral and OpenAI models remotely. Maid is built using React Native and is available for Android. The application is designed to be fast, efficient and user-friendly, making it easy for users to interact with their models on the go.
+Maid is a free and open source application for interfacing with llama.cpp models locally, and with Anthropic, DeepSeek, Mistral, Novita, Ollama and OpenAI models remotely. Maid is built using React Native and is available for Android. The application is designed to be fast, efficient and user-friendly, making it easy for users to interact with their models on the go.
 
-For text to speech functionality check out Maid's companion app [Maise](https://github.com/Mobile-Artificial-Intelligence/maise).
+For text to speech functionality check out Maid's companion app [Maise](https://github.com/Mobile-Artificial-Intelligence-maise).
 
 ## Features
 
 - **Local inference** — run GGUF models fully on-device via llama.cpp; no internet required
-- **Remote providers** — connect to Anthropic, DeepSeek, Mistral, Ollama, and OpenAI with your own API key
+- **Remote providers** — connect to Anthropic, DeepSeek, Mistral, Novita, Ollama, and OpenAI with your own API key
 - **One-tap model downloads** — browse and download curated Hugging Face models (Qwen, Phi, LFM, TinyLlama, and more) directly from the app
 - **Bring your own model** — load any GGUF file from local storage
 - **Conversation management** — create, rename, delete, export, and import chats as JSON

--- a/com.danemadsen.maid.yml
+++ b/com.danemadsen.maid.yml
@@ -1,6 +1,6 @@
 AntiFeatures:
   NonFreeNet:
-    en-US: Optional use of OpenAI, DeepSeek, Anthropic or Mistral APIs. 
+    en-US: Optional use of OpenAI, DeepSeek, Anthropic, Mistral or Novita APIs. 
   NonFreeDep:
     en-US: Depends on Qualcomm Hexagon SDK which is not open source. Binary is not included in release.
 Categories:

--- a/context/language-model/index.tsx
+++ b/context/language-model/index.tsx
@@ -4,6 +4,7 @@ import { AnthropicProvider, useAnthropic } from "./anthropic";
 import { DeepSeekProvider, useDeepSeek } from "./deepseek";
 import { LlamaProvider, useLlama } from "./llama";
 import { MistralProvider, useMistral } from "./mistral";
+import { NovitaProvider, useNovita } from "./novita";
 import { OllamaProvider, useOllama } from "./ollama";
 import { OpenAIProvider, useOpenAI } from "./open-ai";
 import { LanguageModelContextProps, LanguageModelProps, LanguageModelType, LanguageModelTypes } from "./types";
@@ -17,6 +18,7 @@ function LanguageModelManagementProvider({ children }: { children: React.ReactNo
   const anthropic = useAnthropic();
   const mistral = useMistral();
   const deepSeek = useDeepSeek();
+  const novita = useNovita();
   const [type, setType] = useState<LanguageModelType>("Llama");
 
   const loadType = async () => {
@@ -64,6 +66,8 @@ function LanguageModelManagementProvider({ children }: { children: React.ReactNo
         return mistral;
       case "DeepSeek":
         return deepSeek;
+      case "Novita":
+        return novita;
       default:
         throw new Error(`Unsupported model type: ${type}`);
     }
@@ -73,7 +77,7 @@ function LanguageModelManagementProvider({ children }: { children: React.ReactNo
     type,
     setType,
     ...getProps(),
-  }), [type, llama, ollama, openAI, anthropic, mistral, deepSeek]);
+  }), [type, llama, ollama, openAI, anthropic, mistral, deepSeek, novita]);
 
   return (
     <LanguageModelContext.Provider value={values}>
@@ -90,9 +94,11 @@ export function LanguageModelProvider({ children }: { children: React.ReactNode 
           <AnthropicProvider>
             <MistralProvider>
               <DeepSeekProvider>
-                <LanguageModelManagementProvider>
-                  {children}
-                </LanguageModelManagementProvider>
+                <NovitaProvider>
+                  <LanguageModelManagementProvider>
+                    {children}
+                  </LanguageModelManagementProvider>
+                </NovitaProvider>
               </DeepSeekProvider>
             </MistralProvider>
           </AnthropicProvider>

--- a/context/language-model/novita.tsx
+++ b/context/language-model/novita.tsx
@@ -1,0 +1,135 @@
+import useStoredRecord from "@/hooks/use-stored-record";
+import useStoredString from "@/hooks/use-stored-string";
+import { fetch as expoFetch } from "expo/fetch";
+import { MessageNode } from "message-nodes";
+import OpenAI from 'openai';
+import { createContext, useContext, useEffect, useRef, useState } from "react";
+import { NovitaContextProps } from "./types";
+
+const NovitaContext = createContext<NovitaContextProps | undefined>(undefined);
+
+export function NovitaProvider({ children }: { children: React.ReactNode }) {
+  const stopRef = useRef<boolean>(false);
+  const [busy, setBusy] = useState<boolean>(false);
+
+  const [apiKey, setApiKey] = useStoredString("novita-api-key");
+  const [model, setModel] = useStoredString("novita-model");
+
+  const [headers, setHeaders] = useStoredRecord<string, string>("novita-headers");
+  const [parameters, setParameters] = useStoredRecord<string, string | number | boolean>("novita-parameters");
+
+  const [novita, setNovita] = useState<OpenAI | undefined>(undefined);
+  const [models, setModels] = useState<Array<string>>([]);
+
+  useEffect(() => {
+    if (!apiKey) {
+      console.warn("Novita API key not set");
+      return;
+    }
+
+    const novitaInstance = new OpenAI({
+      apiKey,
+      baseURL: "https://api.novita.ai/openai",
+      defaultHeaders: headers,
+      fetch: expoFetch as typeof fetch,
+    });
+
+    setNovita(novitaInstance);
+  }, [apiKey, headers]);
+
+  useEffect(() => {
+    const fetchModels = async () => {
+      if (!novita) return;
+
+      try {
+        const response = await novita.models.list();
+        setModels(response.data.map((model) => model.id));
+      } catch (error) {
+        console.error("Error fetching Novita models:", error);
+      }
+    };
+
+    fetchModels();
+  }, [novita]);
+
+  const prompt = async (
+    messages: Array<MessageNode>,
+    onUpdate: (message: string) => void
+  ) => {
+    if (!novita) {
+      console.warn("Novita not initialized");
+      return;
+    }
+
+    if (!model) {
+      console.warn("Novita model not set");
+      return;
+    }
+
+    setBusy(true);
+
+    const stream = await novita.chat.completions.create({
+      model,
+      messages: messages.map((msg) => ({
+        role: msg.role as "system" | "user" | "assistant",
+        content: msg.content,
+      })),
+      stream: true,
+      ...parameters,
+    }, {
+      maxRetries: 3,
+    });
+
+    
+    for await (const event of stream) {
+      if (stopRef.current) {
+        stream.controller.abort();
+        stopRef.current = false;
+        break;
+      }
+
+      const chunk = event.choices[0]?.delta?.content;
+      if (chunk) {
+        onUpdate(chunk);
+      }
+    }
+    setBusy(false);
+  };
+
+  const stop = async () => {
+    stopRef.current = true;
+  };
+
+  const value = {
+    ready: !!novita && !!model,
+    busy,
+    imagesSupported: false,
+    apiKey,
+    setApiKey,
+    model,
+    setModel,
+    models,
+    parameters,
+    setParameters,
+    headers,
+    setHeaders,
+    prompt,
+    stop
+  };
+
+  return (
+    <NovitaContext.Provider value={value}>
+      {children}
+    </NovitaContext.Provider>
+  );
+}
+
+export function useNovita() {
+  const context = useContext(NovitaContext);
+
+  if (!context) {
+    throw new Error("useNovita must be used within a NovitaProvider");
+  }
+
+  return context;
+}

--- a/context/language-model/types.ts
+++ b/context/language-model/types.ts
@@ -7,6 +7,7 @@ export const LanguageModelTypes = [
   "Anthropic",
   "Mistral",
   "DeepSeek",
+  "Novita",
 ] as const;
 
 export type LanguageModelType = typeof LanguageModelTypes[number];
@@ -67,6 +68,8 @@ export type OpenAIContextProps = LanguageModelBaseProps & ModelMixin & BaseUrlMi
 
 export type DeepSeekContextProps = LanguageModelBaseProps & ModelMixin & HeadersMixin & ApiKeyMixin;
 
+export type NovitaContextProps = LanguageModelBaseProps & ModelMixin & HeadersMixin & ApiKeyMixin;
+
 export type AnthropicContextProps = LanguageModelBaseProps & ModelMixin & BaseUrlMixin & HeadersMixin & ApiKeyMixin;
 
 export type MistralContextProps = LanguageModelBaseProps & ModelMixin & BaseUrlMixin & ApiKeyMixin;
@@ -77,7 +80,8 @@ export type LanguageModelProps =
 | OpenAIContextProps 
 | AnthropicContextProps 
 | MistralContextProps 
-| DeepSeekContextProps;
+| DeepSeekContextProps
+| NovitaContextProps;
 
 export type LanguageModelContextProps = 
 & LanguageModelBaseProps 

--- a/docs/manual.tex
+++ b/docs/manual.tex
@@ -49,7 +49,7 @@
 % ─────────────────────────────────────────────────────────────────────────────
 \section{Introduction}
 
-Maid (Mobile Artificial Intelligence Distribution) is a free and open-source application for interfacing with AI language models on Android. It supports both fully local inference via \texttt{llama.cpp} and remote inference through the APIs of Anthropic, DeepSeek, Mistral, Ollama, and OpenAI.
+Maid (Mobile Artificial Intelligence Distribution) is a free and open-source application for interfacing with AI language models on Android. It supports both fully local inference via \texttt{llama.cpp} and remote inference through the APIs of Anthropic, DeepSeek, Mistral, Novita, Ollama, and OpenAI.
 
 All settings are stored locally on your device using encrypted application storage — no API keys or personal data are sent anywhere other than the provider you configure.
 
@@ -74,6 +74,7 @@ OpenAI   & Yes & Yes & Yes & No  \\
 Anthropic & Yes & Yes & Yes & No  \\
 Mistral  & Yes & Yes & No  & No  \\
 DeepSeek & Yes & No  & Yes & No  \\
+Novita   & Yes & No  & Yes & No  \\
 \bottomrule
 \end{tabular}
 \end{center}
@@ -89,6 +90,7 @@ On the Settings screen, tap the \textbf{API} dropdown at the top of the page to 
     \item \textbf{Anthropic} — Anthropic Claude cloud API
     \item \textbf{Mistral} — Mistral AI cloud API
     \item \textbf{DeepSeek} — DeepSeek cloud API
+    \item \textbf{Novita} — Novita AI cloud API
 \end{itemize}
 
 After selecting a provider, the settings panel will update to show the fields relevant to that provider.
@@ -394,6 +396,44 @@ Model   & Yes & — \\
 \end{tabular}
 \end{center}
 
+\section{Novita}
+
+\subsection{Overview}
+
+The Novita provider connects to Novita AI's cloud API. Novita provides high-performance inference for a wide variety of open-source models through an OpenAI-compatible interface.
+
+\subsection{Obtaining an API Key}
+
+\begin{enumerate}
+    \item Create an account at \url{https://novita.ai}.
+    \item Navigate to your dashboard and generate an API key.
+\end{enumerate}
+
+\subsection{Configuration in Maid}
+
+\begin{enumerate}
+    \item Go to \textbf{Settings} and select \textbf{Novita} from the API dropdown.
+    \item Paste your API key into the \textbf{API Key} field.
+    \item Maid will automatically fetch and populate the \textbf{Model} dropdown.
+    \item Select a model from the available list.
+    \item Optionally configure \textbf{Custom Headers} and \textbf{Parameters} (see Sections~\ref{sec:headers} and~\ref{sec:parameters}).
+\end{enumerate}
+
+\textbf{Note:} The Novita provider always connects to \texttt{https://api.novita.ai/openai}. The base URL is not configurable.
+
+\subsection{Required Fields}
+
+\begin{center}
+\begin{tabular}{lll}
+\toprule
+\textbf{Field} & \textbf{Required} & \textbf{Default} \\
+\midrule
+API Key & Yes & — \\
+Model   & Yes & — \\
+\bottomrule
+\end{tabular}
+\end{center}
+
 % ─────────────────────────────────────────────────────────────────────────────
 \section{Prompt Input}
 
@@ -526,7 +566,7 @@ Parameters that are left blank are omitted from the API request, allowing each p
 \subsection{Custom HTTP Headers}
 \label{sec:headers}
 
-The OpenAI, Anthropic, DeepSeek, and Ollama providers allow you to supply additional HTTP headers. This is useful for:
+The OpenAI, Anthropic, DeepSeek, Novita, and Ollama providers allow you to supply additional HTTP headers. This is useful for:
 
 \begin{itemize}[noitemsep]
     \item Passing organisation or project identifiers required by a corporate proxy.

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,1 +1,1 @@
-Maid is a free and open source application for interfacing with llama.cpp models locally, and with Anthropic, DeepSeek, Ollama, Mistral and OpenAI models remotely.
+Maid is a free and open source application for interfacing with llama.cpp models locally, and with Anthropic, DeepSeek, Mistral, Novita, Ollama and OpenAI models remotely.


### PR DESCRIPTION
## Summary
This PR adds Novita AI as an optional LLM provider. Novita offers high-performance inference for various open-source models via an OpenAI-compatible API.

## Changes
- Updated `LanguageModelTypes` to include Novita.
- Implemented `NovitaProvider` and `useNovita` hook in `context/language-model/novita.tsx`.
- Integrated `NovitaProvider` into the main `LanguageModelProvider`.
- Updated documentation (`README.md`, `docs/manual.tex`, etc.) to include Novita.

## Testing
- Verified that the new provider shows up in the API dropdown.
- Ran existing tests with `yarn test`, which all passed.
- Novita uses the OpenAI SDK, which is already battle-tested in this project.
